### PR TITLE
Add auto-lock-diff.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,15 @@
 {
   "env": {
-      "node": true,
-      "es6": true,
-      "jest": true
+    "node": true,
+    "es6": true,
+    "jest": true
   },
-  "extends": [
-      "airbnb-base"
-  ],
   "rules": {
     "no-param-reassign": "off"
+  },
+  "parser": "babel-eslint",
+  "parserOptions": {
+    "sourceType": "module",
+    "allowImportExportEverywhere": true
   }
 }

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,25 @@
+name: node test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm test
+        env:
+          NODE_OPTIONS: --experimental-vm-modules

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,13 +1,13 @@
-const { diff } = require('../lib/index');
+import { diff } from '../lib/index.js';
 
 describe('diff', () => {
   it('returns an empty object when given two empty objects', () => {
     const oldLock = {
-      dependencies: {},
+      packages: {},
     };
 
     const newLock = {
-      dependencies: {},
+      packages: {},
     };
 
     const changes = diff(oldLock, newLock);

--- a/bin/auto-lock-diff.js
+++ b/bin/auto-lock-diff.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { diff, print } from '../lib/index.js';
+
+const execPromise = promisify(exec);
+
+const lockFiles = async function getLockChangedLockFiles(a, b) {
+    const output = await execPromise(`git diff ${a} ${b} --name-only | grep package-lock.json`);
+    const lines = output.stdout;
+    const list = lines.trim().split(/\r\n|\r|\n/);
+
+    if (output.stderr.trim !== '') {
+        // console.error(output.stderr.trim);
+    }
+
+    return list;
+};
+
+const lockFileString = async function getLockFileString(maxBuffer, branch, filename) {
+    const output = await execPromise(`git show ${branch}:${filename}`, { maxBuffer: maxBuffer });
+    const lines = output.stdout.trim();
+
+    if (output.stderr.trim() !== '') {
+        console.error(output.stderr.trim());
+    }
+
+    return lines;
+};
+
+const cli = new Command();
+cli
+    .version('0.9.0')
+    .arguments('<oldPath> <newPath>')
+    .option('-f, --format <format>', 'changes the output format', 'text')
+    .option('-m, --max-buffer', 'maximum read buffer size', 1024 * 10000)
+    .option('-p, --pretty', 'improves readability of certain output formats', false)
+    .option('-c, --color', 'colorizes certain output formats', false)
+    .action((oldPath, newPath) => {
+        lockFiles(oldPath, newPath).then((v) => {
+            for (let filename of v) {
+                const a = lockFileString(cli.maxBuffer, oldPath, filename).then((s) => { return JSON.parse(s); });
+                const b = lockFileString(cli.maxBuffer, newPath, filename).then((s) => { return JSON.parse(s); });
+                Promise.all([a, b]).then((values) => {
+                    const changes = diff(values[0], values[1]);
+                    print(changes, {
+                        color: cli.color,
+                        format: cli.format,
+                        pretty: cli.pretty,
+                        title: filename,
+                    });
+                });
+            }
+        });
+    })
+    .parse(process.argv);

--- a/bin/lock-diff.js
+++ b/bin/lock-diff.js
@@ -1,25 +1,27 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const commander = require('commander');
-const { diff, print } = require('../lib/index');
+import { readFileSync } from 'fs';
+import { Command } from 'commander';
+import { diff, print } from '../lib/index.js';
 
-commander
-  .version('0.5.0')
+const cli = new Command();
+
+cli
+  .version('0.9.0')
   .arguments('<oldPath> <newPath>')
   .option('-f, --format <format>', 'changes the output format', 'text')
   .option('-p, --pretty', 'improves readability of certain output formats', false)
   .option('-c, --color', 'colorizes certain output formats', false)
   .action((oldPath, newPath) => {
-    const oldLock = JSON.parse(fs.readFileSync(oldPath));
-    const newLock = JSON.parse(fs.readFileSync(newPath));
+    const oldLock = JSON.parse(readFileSync(oldPath));
+    const newLock = JSON.parse(readFileSync(newPath));
 
     const changes = diff(oldLock, newLock);
 
     print(changes, {
-      format: commander.format,
-      pretty: commander.pretty,
-      color: commander.color,
+      format: cli.format,
+      pretty: cli.pretty,
+      color: cli.color,
     });
 
     if (Object.keys(changes).length > 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
-const chalk = require('chalk');
-const semver = require('semver');
-const { table } = require('table');
+import chalk from 'chalk';
+import semver from 'semver';
+import { table } from 'table';
 
-function diff(oldLock, newLock) {
+export function diff(oldLock, newLock) {
   const changes = {};
 
   Object.entries(oldLock.packages).forEach(([name, { version }]) => {
@@ -94,6 +94,9 @@ function printTable(changes, options) {
   }
 
   data.unshift(['package', 'old version', 'new version']);
+  if (options.title !== '') {
+    data.unshift([options.title, '', '']);
+  }
 
   if (options.color) {
     data[0] = data[0].map((heading) => chalk.bold(heading));
@@ -104,7 +107,7 @@ function printTable(changes, options) {
   /* eslint-disable no-console */
 }
 
-function print(changes, options) {
+export function print(changes, options) {
   switch (options.format) {
     case 'json':
       printJSON(changes, options);
@@ -118,8 +121,3 @@ function print(changes, options) {
       break;
   }
 }
-
-module.exports = {
-  diff,
-  print,
-};

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "lock-diff",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "description": "a diff for package-lock.json files",
   "repository": {
     "type": "git",
-    "url": "git@github.com:mayavera/lock-diff.git"
+    "url": "git@github.com:oalders/lock-diff.git"
   },
+  "type": "module",
   "bin": "./bin/lock-diff.js",
   "main": "lib/index.js",
   "author": "Maya Vera <maya@mayavera.me> (https://mayavera.me/)",


### PR DESCRIPTION
- npm update
- Upgrade to parsing to lockfileVersion 3
- Ensure changes[name] is not empty
- Bump table from 5.4.6 to 6.8.1
- Bump eslint-plugin-import from 2.28.0 to 2.28.1
- Add bin/auto-lock-diff.js
